### PR TITLE
Replaced `ERR_EXPLAIN` with `CRASH_NOW_MSG` for 3.2.1 compatibility

### DIFF
--- a/gdnet_host.cpp
+++ b/gdnet_host.cpp
@@ -180,7 +180,7 @@ Error GDNetHost::bind(Ref<GDNetAddress> addr) {
 			penet_addr.host = PENET_HOST_ANY;
 		} else {
 			if (penet_address_set_host(&penet_addr, host_addr.get_data()) != 0) {
-				ERR_EXPLAIN("Unable to resolve host");
+				CRASH_NOW_MSG("Unable to resolve host");
 				return FAILED;
 			}
 		}
@@ -215,7 +215,7 @@ Ref<GDNetPeer> GDNetHost::host_connect(Ref<GDNetAddress> addr, int data) {
 	CharString host_addr = addr->get_host().ascii();
 
 	if (penet_address_set_host(&penet_addr, host_addr.get_data()) != 0) {
-		ERR_EXPLAIN("Unable to resolve host");
+		CRASH_NOW_MSG("Unable to resolve host");
 		return NULL;
 	}
 

--- a/gdnet_host.h
+++ b/gdnet_host.h
@@ -35,9 +35,9 @@ class GDNetHost : public Reference {
 
 	PENetHost* _host;
 	volatile bool _running;
-	Thread* _thread;
-	Mutex* _accessMutex;
-	Mutex* _hostMutex;
+	Thread _thread;
+	Mutex _accessMutex;
+	Mutex _hostMutex;
 
 	int _event_wait;
 	int _max_peers;

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -19,7 +19,7 @@ void register_gdnet3_types() {
 	ClassDB::register_class<GDNetAddress>();
 
 	if (penet_initialize() != 0)
-		ERR_EXPLAIN("Unable to initialize PENet");
+		CRASH_NOW_MSG("Unable to initialize PENet");
 }
 
 void unregister_gdnet3_types() {

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -19,7 +19,7 @@ void register_gdnet3_types() {
 	ClassDB::register_class<GDNetAddress>();
 
 	if (penet_initialize() != 0)
-		CRASH_NOW_MSG("Unable to initialize PENet");
+		ERR_FAIL_COND_MSG("penet_initialize() != 0","Unable to initialize PENet");
 }
 
 void unregister_gdnet3_types() {


### PR DESCRIPTION
Replaced error messaging functions to allow GDNet3 to build for Godot 3.2.1

Related Godot PR: https://github.com/godotengine/godot/pull/33517